### PR TITLE
HP-2693: Fixed missing '3.6.x-dev' package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         }
     ],
     "require": {
-        "yiisoft/composer-config-plugin": "*@dev"
+        "yiisoft/composer-config-plugin": "*@dev",
+        "opis/closure": "3.x-dev as 3.6.x-dev"
     },
     "require-dev": {
         "hiqdev/hidev": "dev-master",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new dependency: opis/closure (3.x-dev as 3.6.x-dev) to required packages.
  * Improves dependency resolution and build reliability across environments.
  * No user-facing changes; existing features and behavior remain unchanged.
  * No action required; the package installs automatically on the next dependency install/update.
  * If you manage deployments, ensure dependency caches/lockfiles are refreshed to pick up the new package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->